### PR TITLE
Footer hover appears over chatbot

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -64,7 +64,7 @@ export default function Footer() {
   ];
 
   return (
-    <footer className="flex items-center justify-between text-sm px-8 md:px-4 py-3 w-full h-20 border-1 border-[#E5E7EB] bg-[#F9FAFB] text-gray-800">
+    <footer className="flex items-center justify-between text-sm px-8 md:px-4 py-3 w-full h-20 border-1 border-[#E5E7EB] bg-[#F9FAFB] text-gray-800 z-50">
       <section>
         <a
           className="flex items-center gap-2 hover:underline underline-offset-2"


### PR DESCRIPTION
# Description

Very small update to have footer tags appear above chatbot.

## Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Summary

Very small update to have footer tags appear above chatbot.

## Related Issues

## Testing instructions

## Screenshots (if applicable)
![DevVault - Google Chrome 6_9_2025 2_31_48 PM](https://github.com/user-attachments/assets/36113eb0-bcec-4e9f-a7e3-2a5eb0d6812e)

## Added Tests?

- [ ] yes
- [x] no
- [ ] separate PR
